### PR TITLE
Allow HadoopJobs to supply additional args to pass to hadoop

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -482,6 +482,8 @@ class HadoopJobRunner(JobRunner):
 
         arglist += self.streaming_args
 
+        arglist += job.jobargs() or []
+
         arglist += ['-mapper', map_cmd]
         if job.combiner != NotImplemented:
             arglist += ['-combiner', cmb_cmd]
@@ -646,6 +648,9 @@ class BaseHadoopJobTask(luigi.Task):
             elif scheduler_type == 'capacity':
                 jcs.append('mapred.job.queue.name=%s' % pool)
         return jcs
+
+    def jobargs(self):
+        return []
 
     def init_local(self):
         """


### PR DESCRIPTION
Tough to unit test this completely because the hadoop unit tests hang and never complete.  See this comment:  https://github.com/SkyTruth/luigi/commit/23c676d1a56749b96b4f984d04c3156489656fa8

Managed to run the tests directly and everything seems to work.   
