### PR TITLE
Allow GCSTarget()'s for input and output.

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -51,6 +51,7 @@ from luigi import six
 from luigi import configuration
 import luigi
 import luigi.task
+import luigi.contrib.gcs
 import luigi.contrib.hdfs
 import luigi.s3
 from luigi import mrrunner
@@ -499,15 +500,23 @@ class HadoopJobRunner(JobRunner):
         if self.input_format:
             arglist += ['-inputformat', self.input_format]
 
+        allowed_input_targets = (
+            luigi.contrib.hdfs.HdfsTarget,
+            luigi.s3.S3Target,
+            luigi.contrib.gcs.GCSTarget)
         for target in luigi.task.flatten(job.input_hadoop()):
-            if not isinstance(target, luigi.contrib.hdfs.HdfsTarget) \
-                    and not isinstance(target, luigi.s3.S3Target):
-                raise TypeError('target must be an HdfsTarget or S3Target')
+            if not isinstance(target, allowed_input_targets):
+                raise TypeError('target must one of: {}'.format(
+                    allowed_input_targets))
             arglist += ['-input', target.path]
 
-        if not isinstance(job.output(), luigi.contrib.hdfs.HdfsTarget) \
-                and not isinstance(job.output(), luigi.s3.S3FlagTarget):
-            raise TypeError('output must be an HdfsTarget or S3FlagTarget')
+        allowed_output_targets = (
+            luigi.contrib.hdfs.HdfsTarget,
+            luigi.s3.S3FlagTarget,
+            luigi.contrib.gcs.GCSFlagTarget)
+        if not isinstance(job.output(), allowed_output_targets):
+            raise TypeError('output must be one of: {}'.format(
+                allowed_output_targets))
         arglist += ['-output', output_hadoop]
 
         # submit job

--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -437,9 +437,11 @@ class HadoopJobRunner(JobRunner):
         output_final = job.output().path
         # atomic output: replace output with a temporary work directory
         if self.end_job_with_atomic_move_dir:
-            if isinstance(job.output(), luigi.s3.S3FlagTarget):
+            illegal_targets = (
+                luigi.s3.S3FlagTarget, luigi.contrib.gcs.GCSFlagTarget)
+            if isinstance(job.output(), illegal_targets):
                 raise TypeError("end_job_with_atomic_move_dir is not supported"
-                                " for S3FlagTarget")
+                                " for {}".format(illegal_targets))
             output_hadoop = '{output}-temp-{time}'.format(
                 output=output_final,
                 time=datetime.datetime.now().isoformat().replace(':', '-'))


### PR DESCRIPTION
**This PR must mirror https://github.com/spotify/luigi/pull/1664 before merging.**

For https://github.com/SkyTruth/benthos-pipeline/issues/522

This PR gives our internal branch the same changes that were submitted to https://github.com/spotify/luigi/pull/1664, which allows `GCSTarget()`'s as input and output for Hadoop jobs.

This is to help get us onto Luigi 2 and Hadoop 2 by way of cleaning up our Hadoop infrastructure first.  The changes in this PR should ultimately mirror what is merged from [`geowurster:hadoop-gcs`](https://github.com/geowurster/luigi/tree/hadoop-gcs) so we can get the improvements on our internal Luigi 1 branch.
